### PR TITLE
Remove RepositoryRestMvcConfiguration subclasses

### DIFF
--- a/rest-microservices-customers/src/main/java/example/customers/CustomerApp.java
+++ b/rest-microservices-customers/src/main/java/example/customers/CustomerApp.java
@@ -15,12 +15,14 @@
  */
 package example.customers;
 
+import javax.annotation.PostConstruct;
+
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.circuitbreaker.EnableCircuitBreaker;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.data.rest.core.config.RepositoryRestConfiguration;
-import org.springframework.data.rest.webmvc.config.RepositoryRestMvcConfiguration;
 
 /**
  * @author Oliver Gierke
@@ -28,11 +30,14 @@ import org.springframework.data.rest.webmvc.config.RepositoryRestMvcConfiguratio
 @SpringBootApplication
 @EnableCircuitBreaker
 @EnableDiscoveryClient
-public class CustomerApp extends RepositoryRestMvcConfiguration {
-	
-	@Override
-	protected void configureRepositoryRestConfiguration(RepositoryRestConfiguration config) {
-		config.exposeIdsFor(Customer.class);
+public class CustomerApp {
+
+	@Autowired
+	private RepositoryRestConfiguration repositoryRestConfiguration;
+
+	@PostConstruct
+	public void exposeIds() {
+		this.repositoryRestConfiguration.exposeIdsFor(Customer.class);
 	}
 
 	public static void main(String[] args) {

--- a/rest-microservices-store/src/main/java/example/stores/StoreApp.java
+++ b/rest-microservices-store/src/main/java/example/stores/StoreApp.java
@@ -17,16 +17,16 @@ package example.stores;
 
 import java.util.List;
 
+import javax.annotation.PostConstruct;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.rest.core.config.RepositoryRestConfiguration;
-import org.springframework.data.rest.webmvc.config.RepositoryRestMvcConfiguration;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -39,13 +39,15 @@ import org.springframework.web.bind.annotation.ResponseBody;
 @EnableAutoConfiguration
 @ComponentScan
 @EnableDiscoveryClient
-@Import(RepositoryRestMvcConfiguration.class)
-public class StoreApp extends RepositoryRestMvcConfiguration {
+public class StoreApp {
 
-    @Override
-    protected void configureRepositoryRestConfiguration( RepositoryRestConfiguration config) {
-        config.exposeIdsFor(Store.class);
-    }
+	@Autowired
+	private RepositoryRestConfiguration repositoryRestConfiguration;
+
+	@PostConstruct
+	public void exposeIds() {
+		this.repositoryRestConfiguration.exposeIdsFor(Store.class);
+	}
 
 	public static void main(String[] args) {
 		SpringApplication.run(StoreApp.class, args);


### PR DESCRIPTION
Remove `RepositoryRestMvcConfiguration` subclasses so that the `@Primary` `ObjectMapper` is auto-configured by `JackonAutoConfiguration`. These changes allow both apps to start, but I haven't tested beyond that as I could not get the config server to build and run from source.