### PR TITLE
Find nearby stores

### DIFF
--- a/customers-stores-ui/bootstrap.yml
+++ b/customers-stores-ui/bootstrap.yml
@@ -3,6 +3,4 @@ spring:
     name: customersui
   cloud:
     config:
-     uri: ${vcap.services.${PREFIX:}configserver.credentials.uri:${CONFIG_SERVER_URI:http://localhost:8888}}
-     failFast: true
-      
+      uri: ${vcap.services.${PREFIX:}configserver.credentials.uri:${CONFIG_SERVER_URI:http://localhost:8888}}

--- a/rest-microservices-customers/src/main/java/example/customers/integration/CustomerResourceProcessor.java
+++ b/rest-microservices-customers/src/main/java/example/customers/integration/CustomerResourceProcessor.java
@@ -40,6 +40,7 @@ import example.customers.Location;
 public class CustomerResourceProcessor implements ResourceProcessor<Resource<Customer>> {
 
 	private static final String X_FORWARDED_HOST = "X-Forwarded-Host";
+	private static final String X_FORWARDED_PORT = "X-Forwarded-Port";
 	private final StoreIntegration storeIntegration;
 	private final Provider<HttpServletRequest> request;
 
@@ -53,7 +54,13 @@ public class CustomerResourceProcessor implements ResourceProcessor<Resource<Cus
 		parameters.put("location", String.format("%s,%s", location.getLatitude(), location.getLongitude()));
 		parameters.put("distance", "50km");
 		String host = this.request.get().getHeader(X_FORWARDED_HOST);
-		Link link = this.storeIntegration.getStoresByLocationLink(parameters, host);
+
+		Integer port = null;
+		if(this.request.get().getHeader(X_FORWARDED_PORT)!=null){
+			port = Integer.parseInt(this.request.get().getHeader(X_FORWARDED_PORT));
+		}
+
+		Link link = this.storeIntegration.getStoresByLocationLink(parameters, host, port);
 		if (link != null) {
 			resource.add(link.withRel("stores-nearby"));
 		}

--- a/rest-microservices-store/src/main/resources/bootstrap.yml
+++ b/rest-microservices-store/src/main/resources/bootstrap.yml
@@ -3,4 +3,5 @@ spring:
     name: stores
   cloud:
     config:
-      uri: ${CONFIG_SERVER_URI:${vcap.services.${PREFIX:}configserver.credentials.uri:http://user:password@localhost:8888}}
+      uri: ${vcap.services.${PREFIX:}configserver.credentials.uri:${CONFIG_SERVER_URI:http://localhost:8888}}
+      failFast: false


### PR DESCRIPTION
Fixes in order to:
1. **get the app to run**: customers-stores-ui and rest-microservices-store fail to start when there is no config server
2. **show the stores nearby**: when building the URL to retrieve the stores nearby, the call should be made to the edge server instead of port 80
